### PR TITLE
next.config.jsにNext/Image用のデバイスサイズの設定を追加

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,1 +1,6 @@
-module.exports = {};
+module.exports = {
+  images: {
+    deviceSizes: [340, 640, 768, 1024, 1280, 1440, 1980],
+    domains: ['localhost:3000'],
+  },
+};


### PR DESCRIPTION
fix #33 